### PR TITLE
Added a regex format for date for use in customer

### DIFF
--- a/schemas/customer-create.schema.json
+++ b/schemas/customer-create.schema.json
@@ -32,7 +32,7 @@
       "type": "string"
     },
     "dateOfBirth": {
-      "type": "full-date"
+      "$ref": "date.schema.json"
     },
     "companyName": {
       "type": "string"

--- a/schemas/customer-create.schema.json
+++ b/schemas/customer-create.schema.json
@@ -32,7 +32,7 @@
       "type": "string"
     },
     "dateOfBirth": {
-      "$ref": "date.schema.json"
+      "type": "full-date"
     },
     "companyName": {
       "type": "string"

--- a/schemas/customer-create.schema.json
+++ b/schemas/customer-create.schema.json
@@ -32,7 +32,7 @@
       "type": "string"
     },
     "dateOfBirth": {
-      "type": "date"
+      "$ref": "date.schema.json"
     },
     "companyName": {
       "type": "string"

--- a/schemas/customer-update.schema.json
+++ b/schemas/customer-update.schema.json
@@ -209,7 +209,7 @@
               "enum": ["setDateOfBirth"]
             },
             "dateOfBirth": {
-              "$ref": "date.schema.json",
+              "type": "full-date",
               "description": "If not defined, the date of birth is unset."
             }
           }

--- a/schemas/customer-update.schema.json
+++ b/schemas/customer-update.schema.json
@@ -209,7 +209,7 @@
               "enum": ["setDateOfBirth"]
             },
             "dateOfBirth": {
-              "type": "date",
+              "$ref": "date.schema.json",
               "description": "If not defined, the date of birth is unset."
             }
           }

--- a/schemas/customer-update.schema.json
+++ b/schemas/customer-update.schema.json
@@ -209,7 +209,7 @@
               "enum": ["setDateOfBirth"]
             },
             "dateOfBirth": {
-              "type": "full-date",
+              "$ref": "date.schema.json",
               "description": "If not defined, the date of birth is unset."
             }
           }

--- a/schemas/customer.schema.json
+++ b/schemas/customer.schema.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "dateOfBirth": {
-      "type": "date"
+      "$ref":"date.schema.json"
     },
     "companyName": {
       "type": "string"

--- a/schemas/customer.schema.json
+++ b/schemas/customer.schema.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "dateOfBirth": {
-      "type":"full-date"
+      "$ref":"date.schema.json"
     },
     "companyName": {
       "type": "string"

--- a/schemas/customer.schema.json
+++ b/schemas/customer.schema.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "dateOfBirth": {
-      "$ref":"date.schema.json"
+      "type":"full-date"
     },
     "companyName": {
       "type": "string"

--- a/schemas/date.schema.json
+++ b/schemas/date.schema.json
@@ -2,7 +2,7 @@
   "$schema":"http://json-schema.org/draft-04/schema#",
 
   "type":"string",
-  "format":"full-date",
+  "pattern":"^\\d{4}-\\d{2}-\\d{2}$",
   "description":"A date in the format YYYY-MM-DD."
 }
 

--- a/schemas/date.schema.json
+++ b/schemas/date.schema.json
@@ -1,7 +1,0 @@
-{
-  "$schema":"http://json-schema.org/draft-04/schema#",
-
-  "type":"string",
-  "pattern":"^\d{4}-((0[1-9])|(1[012]))-((0[1-9]|[12]\d)|3[01])$"
-}
-

--- a/schemas/date.schema.json
+++ b/schemas/date.schema.json
@@ -2,6 +2,7 @@
   "$schema":"http://json-schema.org/draft-04/schema#",
 
   "type":"string",
-  "pattern":"^\d{4}-((0[1-9])|(1[012]))-((0[1-9]|[12]\d)|3[01])$"
+  "format":"full-date",
+  "description":"A date in the format YYYY-MM-DD."
 }
 

--- a/schemas/date.schema.json
+++ b/schemas/date.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema":"http://json-schema.org/draft-04/schema#",
+
+  "type":"string",
+  "pattern":"^\d{4}-((0[1-9])|(1[012]))-((0[1-9]|[12]\d)|3[01])$"
+}
+


### PR DESCRIPTION
Found this bug thanks to @nkuehn validator :)

The regex should be correct for values we emit.

For create/update, our parser actually accepts more values than the regex does... If anyone wants to, they can build a regex from this: https://github.com/JodaOrg/joda-time/blob/a3b1a16ee43af611939799a99c7c461d051d40e7/src/main/java/org/joda/time/format/ISODateTimeFormat.java#L1345-L1370 :wink: However, I don't really see a need to support formats other than YYYY-MM-DD (including, e.g. YYYY).

Please review @agourlay or @OlegIlyenko